### PR TITLE
[HN-52] chore: use llama-index v0.10.35

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.110.1
 uvicorn==0.23.2
 python-dotenv==1.0.1
-llama-index==0.10.19
+llama-index==0.10.35
 web3==6.15.1
 py-solc-x==2.0.2
 eth-account==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         'fastapi==0.109.1',
         'uvicorn==0.23.2',
         'python-dotenv==1.0.1',
-        'llama-index==0.10.19',
+        'llama-index==0.10.35',
         'web3==6.15.1',
         'py-solc-x==2.0.2',
         'eth-account==0.11.0',


### PR DESCRIPTION
Updated the version of llama-index to the latest to resolve lack of backwards compatibility from their recent changes.